### PR TITLE
Panel column generator failing because pandas apply is columnwise by default

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -339,7 +339,8 @@ def submit_libraries_to_pieriandx(processing_df: pd.DataFrame) -> pd.DataFrame:
     processing_df["panel_type"] = processing_df.apply(
         lambda x: "main"
         if (x.is_validation_sample or x.is_research_sample)
-        else "subpanel"
+        else "subpanel",
+        axis="columns"
     )
 
     processing_df["submission_succeeded"] = False


### PR DESCRIPTION
Set axis=columns instead 'applies' function to each row (TBH this should be the default but I'm not pingu - (who is a penguin not a panda, so maybe I am pingu)).