### PR TITLE
Increase number of submissions per lims cycle from 15 samples to 20 samples

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/globals.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/globals.py
@@ -50,7 +50,7 @@ PIERIANDX_LAMBDA_LAUNCH_FUNCTION_ARN_SSM_PATH = "cttso-ica-to-pieriandx-lambda-f
 
 MAX_ATTEMPTS_GET_CASES = 5
 LIST_CASES_RETRY_TIME = 5
-MAX_SUBMISSIONS_PER_LIMS_UPDATE_CYCLE = 15
+MAX_SUBMISSIONS_PER_LIMS_UPDATE_CYCLE = 20
 MAX_ATTEMPTS_WAKE_LAMBDAS = 5
 
 LOGGER_STYLE = "%(asctime)s - %(levelname)-8s - %(module)-25s - %(funcName)-40s : LineNo. %(lineno)-4d - %(message)s"


### PR DESCRIPTION
Since fixing https://github.com/umccr/cttso-ica-to-pieriandx/issues/16, we no longer need to wait for each lambda to complete (this means we are less likely to timeout while submitting batch jobs).