### PR TITLE
Update Docker Base image to latest (22.9.0-3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/condaforge/mambaforge:4.10.3-7
+FROM quay.io/condaforge/mambaforge:22.9.0-3
 
 # Set args
 ARG CONDA_GROUP_NAME="cttso_ica_to_pieriandx_group"


### PR DESCRIPTION
Mamba was failing build using old base, update to latest version