### PR TITLE
Fix submission_arn column assignment for research samples with incomplete redcap information

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -333,7 +333,11 @@ def submit_libraries_to_pieriandx(processing_df: pd.DataFrame) -> pd.DataFrame:
     # Validation if is validation sample or IS research sample with no redcap information
     processing_df["submission_arn"] = processing_df.apply(
         lambda x: get_validation_lambda_arn()
-        if x.is_validation_sample or (x.is_research_sample and not x.redcap_is_complete)
+        if x.is_validation_sample or (x.is_research_sample and (
+                pd.isnull(x.redcap_is_complete) or
+                not x.redcap_is_complete.lower() == "complete"
+            )
+        )
         else get_clinical_lambda_arn(),
         axis="columns"
     )


### PR DESCRIPTION
_redcap_is_complete_ column cannot be treated as a boolean, instead use pd.isnull to determine if value is empty

Fixes #38