### PR TITLE
Downgrade pandas to version 1.5.3

### DIFF
--- a/cttso-ica-to-pieriandx-conda-env.yaml
+++ b/cttso-ica-to-pieriandx-conda-env.yaml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - pandas
   - ca-certificates
   - openssl
   - pip:
+      - pandas<2
       - pyriandx==0.3.0
       - libica==0.5.0
       - python-dateutil==2.8.2


### PR DESCRIPTION
Version of pandas is now at <2.0.0 (1.5.3)
Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/54

