### PR TITLE
June updates to PierianDx Transfer Deployment

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,65 @@
+name: Create and Upload Release And Docker Container(s)
+
+on:
+  pull_request:
+   # Sequence of patterns matched against refs/tags
+   branches:
+    - main
+
+jobs:
+  # First job
+  check_changelog:
+    name: Check Changelog has been updated
+    runs-on: ubuntu-latest
+    steps:
+      # Standard checkout step
+      - name: Checkout code
+        id: git_checkout
+        uses: actions/checkout@v3
+      # Get all file changes
+      - name: Get All Changed Files
+        id: get_all_changed_files
+        uses: tj-actions/changed-files@v36
+      # Get all changed in deploy directory
+      - name: Get Deployment Changed Files
+        id: get_deployment_changed_files
+        uses: tj-actions/changed-files@v36
+        with:
+          files: deploy/*
+      # List all changed files
+      - name: Check Main Changelog
+        # Check any files changed AND not just ones in deploy
+        if: >-
+          ${{ 
+            steps.get_all_changed_files.any_changed == 'true' && 
+            ( steps.get_all_changed_files.all_changed_files != steps.get_all_changed_files.all_changed_files ) 
+          }}
+        id: check_main_changelog
+        run: |
+          for file in ${{ steps.get_all_changed_files.outputs.all_changed_files }}; do
+            if [[ "${file}" == "Changelog.md" ]]; then
+              echo "Changelog.md has been modified. Passed main changelog test" 1>&2
+              exit 0
+            fi
+          done
+          echo "Did not find changelog in list of changed files" 1>&2
+          exit 1
+        # Check if deploy changelog has been updated
+      - name: Check Deploy Changelog
+        # Check any files changed in deploy
+        if: >-
+          ${{ 
+            steps.get_deployment_changed_files.any_changed == 'true' 
+          }}
+        id: check_deploy_changelog
+        run: |
+          for file in ${{ steps.get_deployment_changed_files.outputs.all_changed_files }}; do
+            if [[ "${file}" == "deploy/cttso-ica-to-pieriandx-cdk/Changelog.md" ]]; then
+              echo "deploy/cttso-ica-to-pieriandx/Changelog.md has been modified. Passed deploy changelog test" 1>&2
+              exit 0
+            fi
+          done
+          echo "Did not find changelog in list of changed files" 1>&2
+          exit 1
+
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@ Changes in this log refer only to changes that make it to the 'main' branch. and
 
 For changes in deployment, please see the [deployment changelog](deploy/cttso-ica-to-pieriandx-cdk/Changelog.md) 
 
+## 2023-05-07
+
+> Author: Alexis Lucattini
+> Email: [Alexis.Lucattini@ummcr.org](mailto:alexis.lucattini@umccr.org)
+
+### Hotfix
+
+Force pandas downgrade (https://github.com/umccr/cttso-ica-to-pieriandx/pull/55)
+ * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/54
+
 ## 2023-02-15
 
 > Author: Alexis Lucattini

--- a/deploy/cttso-ica-to-pieriandx-cdk/Changelog.md
+++ b/deploy/cttso-ica-to-pieriandx-cdk/Changelog.md
@@ -28,6 +28,10 @@ are nested under deploy/cttso-ica-to-pieriandx-cdk.
 * Check if new password can successfully generate pieriandx session token before successfully exiting script (https://github.com/umccr/cttso-ica-to-pieriandx/pull/57)
   * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/56
 
+### Dependabot Updates
+
+* Migrated from AWS 2.39.1 to 2.80.0 (https://github.com/umccr/cttso-ica-to-pieriandx/pull/74)
+
 ## 2023-04-14
 
 * Prevent NTCs from being uploaded to PierianDx (https://github.com/umccr/cttso-ica-to-pieriandx/pull/52)

--- a/deploy/cttso-ica-to-pieriandx-cdk/Changelog.md
+++ b/deploy/cttso-ica-to-pieriandx-cdk/Changelog.md
@@ -3,10 +3,47 @@
 Changes in this log refer only to changes that make it to the 'main' branch and
 are nested under deploy/cttso-ica-to-pieriandx-cdk.  
 
+## 2023-06-23
+
+> Author: Alexis Lucattini
+> Email: [Alexis.Lucattini@umccr.org](mailto:alexis.lucattini@umccr.org)
+
+### Fixes
+
+* Fix Type Hinting for EventClient Type (https://github.com/umccr/cttso-ica-to-pieriandx/pull/71)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/68
+* Don't use RequestResponse event type when manually deploying lambdas (https://github.com/umccr/cttso-ica-to-pieriandx/pull/64)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/63
+* Get Incomplete Job Df from Gsuite doesn't collect pending jobs at times (https://github.com/umccr/cttso-ica-to-pieriandx/pull/66
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/61
+
+### Enhancements
+
+* Added GH Actions check to ensure this changelog file has been updated before deployment (https://github.com/umccr/cttso-ica-to-pieriandx/pull/73)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/70
+
+* Added EventBridge kill switch if processing_df contains items included in the update_df (shouldn't happen) (https://github.com/umccr/cttso-ica-to-pieriandx/pull/67)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/62
+
+* Check if new password can successfully generate pieriandx session token before successfully exiting script (https://github.com/umccr/cttso-ica-to-pieriandx/pull/57)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/56
+
+## 2023-04-14
+
+* Prevent NTCs from being uploaded to PierianDx (https://github.com/umccr/cttso-ica-to-pieriandx/pull/52)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/49
+
+* Add new PierianDx Submission Time Column to LIMS Sheet (https://github.com/umccr/cttso-ica-to-pieriandx/issues/47)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/47
+
+* Handle submission edge case of SBJ01666 (https://github.com/umccr/cttso-ica-to-pieriandx/pull/50)
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/46
+  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/48
+
 ## 2023-02-15
 
 > Author: Alexis Lucattini
-> Email: [Alexis.Lucattini@ummcr.org](mailto:alexis.lucattini@umccr.org)
+> Email: [Alexis.Lucattini@umccr.org](mailto:alexis.lucattini@umccr.org)
 
 ### Fixes
 

--- a/deploy/cttso-ica-to-pieriandx-cdk/README.md
+++ b/deploy/cttso-ica-to-pieriandx-cdk/README.md
@@ -119,11 +119,17 @@ Run `update-params.sh` in your console and changed ssm parameters will be update
 
 The PierianDx password must be updated every three months and is a manual process. 
 
-This requires the user to log in to [app.pieriandx.com](https://app.pieriandx.com) and update their password. 
+This requires the user to log in to [app.pieriandx.com](https://app.pieriandx.com) and update their password.
 
-Once updated in PierianDx, the user should run the update-pieriandx-password.sh in both the dev and prod accounts.  
+The new password should be 20 characters and contain lowercase, uppercase and numbers (no symbols)! 
 
-This will prompt the user for the new password and will update the AWS secretsmanager respectively.  
+Once updated in PierianDx, the user should run the update-pieriandx-password.sh in **both the dev and prod accounts**.  
+
+This will prompt the user for the new password and will update the AWS secretsmanager respectively.
+
+The script will also test that the new password can successfully create a new PierianDx Auth token.  
+
+One should also update the password in [KeyBase](https://keybase.io/) under 'vccc.umccr.admin/pieriandx_service_user.txt'
 
 ### ./scripts/launch_direct_cttso_lambda_from_glims
 

--- a/deploy/cttso-ica-to-pieriandx-cdk/constants.ts
+++ b/deploy/cttso-ica-to-pieriandx-cdk/constants.ts
@@ -37,6 +37,7 @@ export const SSM_VALIDATION_LAMBDA_FUNCTION_ARN_VALUE: string = "validation-samp
 // LIMS things
 export const GLIMS_SSM_PARAMETER_PATH: string = "/umccr/google/drive"
 export const SSM_LIMS_LAMBDA_FUNCTION_ARN_VALUE: string = "cttso-lims-update-and-launch-lambda-function"
+export const SSM_LIMS_LAMBDA_FUNCTION_EVENT_RULE_NAME_VALUE: string = "cttso-lims-update-and-launch-lambda-function-rule-name"
 
 // Token refresher things
 export const SSM_TOKEN_REFRESH_LAMBDA_FUNCTION_ARN_VALUE: string = "token-refresher-for-pieriandx-lambda-function"

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -1587,3 +1587,9 @@ def lambda_handler(event, context):
 
     # End of process
     logger.info("End of lims script")
+
+
+## LOCAL DEBUG ONLY ##
+# if __name__ == "__main__":
+#     lambda_handler(None, None)
+##

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -619,18 +619,23 @@ def get_pieriandx_incomplete_job_df_from_cttso_lims_df(cttso_lims_df: pd.DataFra
     """
     static_statuses = ["complete", "failed", "canceled"]
 
+    # Get cases where pieriandx case id is pending
     return cttso_lims_df.query(
         "( "
-        "  ( "
-        "    not pieriandx_case_id.isnull() or "
+        "  ("
         "    pieriandx_case_id == 'pending' "
         "  ) "
-        "  and "
+        "  or "
         "  ( "
-        "    pieriandx_workflow_id.isnull() or "
-        "    not pieriandx_workflow_status in @static_statuses or "
-        "    not pieriandx_report_status in @static_statuses"
-        "  )"
+        "    ( "
+        "      not pieriandx_case_id.isnull() "
+        "    ) and "
+        "    ( "
+        "      pieriandx_workflow_id.isnull() or "
+        "      not pieriandx_workflow_status in @static_statuses or "
+        "      not pieriandx_report_status in @static_statuses"
+        "    ) "
+        "  ) "
         ")",
         engine="python"
     )

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -32,6 +32,8 @@ Cells are indexed by Subject and Library ID values, the following items can be u
 
 Values with new Subject and Library ID values will be appended
 """
+import sys
+
 from mypy_boto3_lambda.client import LambdaClient
 from mypy_boto3_lambda.type_defs import GetFunctionResponseTypeDef, FunctionConfigurationTypeDef, InvocationResponseTypeDef
 
@@ -46,7 +48,7 @@ from time import sleep
 from datetime import datetime, timedelta
 
 from lambda_utils.arns import get_validation_lambda_arn, get_clinical_lambda_arn
-from lambda_utils.aws_helpers import get_boto3_lambda_client, get_boto3_ssm_client
+from lambda_utils.aws_helpers import get_boto3_lambda_client, get_boto3_ssm_client, get_boto3_events_client
 from lambda_utils.gspread_helpers import \
     get_cttso_samples_from_glims, get_cttso_lims, update_cttso_lims_row, \
     append_df_to_cttso_lims
@@ -59,7 +61,7 @@ from lambda_utils.globals import \
     REDCAP_APIS_LAMBDA_FUNCTION_ARN_SSM_PARAMETER, \
     CLINICAL_LAMBDA_FUNCTION_SSM_PARAMETER_PATH, \
     VALIDATION_LAMBDA_FUNCTION_ARN_SSM_PARAMETER_PATH, \
-    MAX_SUBMISSIONS_PER_LIMS_UPDATE_CYCLE, MAX_ATTEMPTS_WAKE_LAMBDAS
+    MAX_SUBMISSIONS_PER_LIMS_UPDATE_CYCLE, MAX_ATTEMPTS_WAKE_LAMBDAS, EVENT_RULE_FUNCTION_NAME_SSM_PARAMETER_PATH
 
 logger = get_logger()
 
@@ -1449,6 +1451,23 @@ def lambdas_awake() -> bool:
     return False
 
 
+def disable_event_rule():
+    """
+    List and disable event trigger (important to prevent duplicate runs)
+    :return:
+    """
+    # Clients
+    ssm_client = get_boto3_ssm_client()
+    events_client = get_boto3_events_client()
+
+    event_function_name = ssm_client.get_parameter(Name=EVENT_RULE_FUNCTION_NAME_SSM_PARAMETER_PATH)\
+        .get("Parameter")\
+        .get("Value")
+
+    # Disable rule
+    events_client.disable_rule(Name=event_function_name)
+
+
 def lambda_handler(event, context):
     """
     Neither event or context are used by the handler as this job is scheduled hourly
@@ -1492,6 +1511,7 @@ def lambda_handler(event, context):
 
     # Update values for jobs with missing information
     if not pieriandx_incomplete_jobs_df.shape[0] == 0:
+        logger.info(f"Attempting to update {pieriandx_incomplete_jobs_df.shape[0]} rows of jobs that are incomplete")
         pieriandx_jobs_missing_series: List = []
         for index, row in pieriandx_incomplete_jobs_df.iterrows():
             case_id = row["pieriandx_case_id"]
@@ -1499,22 +1519,27 @@ def lambda_handler(event, context):
                 continue
             if case_id == "pending":
                 case_id = get_pieriandx_case_id_from_merged_df_for_pending_case(row, merged_df)
+                logger.info(f"Got case '{case_id}' for pending analysis {row['subject_id']} {row['library_id']}")
 
             if case_id is not None and not pd.isnull(case_id):
                 pieriandx_jobs_missing_series.append(get_pieriandx_status_for_missing_sample(case_id))
 
         # If any missing samples found, get latest info and update
         if not len(pieriandx_jobs_missing_series) == 0:
+            logger.info(f"Got {len(pieriandx_jobs_missing_series)} rows to replace")
             pieriandx_job_status_missing_df = pd.concat(pieriandx_jobs_missing_series, axis="columns").transpose()
 
             # Merge pieriandx_job_status_missing_df with merged_df so all rows are present
             pieriandx_job_status_missing_df = update_pieriandx_job_status_missing_df(pieriandx_job_status_missing_df, merged_df)
 
             # Update cttso lims df
+            logger.info("Updating lims")
             update_cttso_lims(pieriandx_job_status_missing_df, cttso_lims_df, excel_row_number_mapping_df)
 
-            # Reimport the data sheet after updating
-            sleep(3)
+            # Reimport the data sheet after updating (give it a minute)
+            sleep(60)
+
+            # Reimport lims
             cttso_lims_df: pd.DataFrame
             excel_row_number_mapping_df: pd.DataFrame
             cttso_lims_df, excel_row_number_mapping_df = get_cttso_lims()
@@ -1525,6 +1550,21 @@ def lambda_handler(event, context):
 
     # Get pieriandx df samples in merged df that are not in pieriandx_df
     processing_df = get_libraries_for_processing(merged_df)
+
+    # Check if any of the processing df are present in the incomplete jobs df
+    for index, row in processing_df.iterrows():
+        if pieriandx_incomplete_jobs_df.query(
+                f"subject_id=='{row['subject_id']}' "
+                f"and "
+                f"library_id=='{row['library_id']}'"
+        ).shape[0] > 0:
+            logger.error(
+                f"Issue in getting library for processing, {row['subject_id']}/{row['library_id']} "
+                f"has already been submitted for processing. "
+                "Please fix this manually, stopping all further submissions then reenable the event bridge"
+            )
+            disable_event_rule()
+            sys.exit(1)
 
     # Launch payloads for pieriandx_df samples that have no case id - if existent
     if not processing_df.shape[0] == 0:

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/aws_helpers.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/aws_helpers.py
@@ -8,6 +8,7 @@ from botocore.client import BaseClient
 from mypy_boto3_ssm.client import SSMClient
 from mypy_boto3_lambda.client import LambdaClient
 from mypy_boto3_secretsmanager.client import SecretsManagerClient
+from mypy_boto3_events.client import EventsClient
 from typing import Union
 import boto3
 
@@ -40,3 +41,6 @@ def get_boto3_ssm_client() -> Union[SSMClient, BaseClient]:
 def get_boto3_secretsmanager_client() -> Union[SecretsManagerClient, BaseClient]:
     return boto3.client("secretsmanager")
 
+
+def get_boto3_events_client() -> Union[EventsClient, BaseClient]:
+    return boto3.client("events")

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/aws_helpers.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/aws_helpers.py
@@ -8,7 +8,7 @@ from botocore.client import BaseClient
 from mypy_boto3_ssm.client import SSMClient
 from mypy_boto3_lambda.client import LambdaClient
 from mypy_boto3_secretsmanager.client import SecretsManagerClient
-from mypy_boto3_events.client import EventsClient
+from mypy_boto3_events.client import EventBridgeClient
 from typing import Union
 import boto3
 
@@ -42,5 +42,5 @@ def get_boto3_secretsmanager_client() -> Union[SecretsManagerClient, BaseClient]
     return boto3.client("secretsmanager")
 
 
-def get_boto3_events_client() -> Union[EventsClient, BaseClient]:
+def get_boto3_events_client() -> Union[EventBridgeClient, BaseClient]:
     return boto3.client("events")

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/globals.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/globals.py
@@ -61,6 +61,9 @@ REDCAP_APIS_LAMBDA_FUNCTION_ARN_SSM_PARAMETER: str = "redcap-apis-lambda-functio
 # Clinical lambda path
 CLINICAL_LAMBDA_FUNCTION_SSM_PARAMETER_PATH = "redcap-to-pieriandx-lambda-function"
 
+# Event Rule
+EVENT_RULE_FUNCTION_NAME_SSM_PARAMETER_PATH = "cttso-lims-update-and-launch-lambda-function-rule-name"
+
 # Validation lambda path
 VALIDATION_LAMBDA_FUNCTION_ARN_SSM_PARAMETER_PATH = "validation-sample-to-pieriandx-lambda-function"
 

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/gspread_helpers.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/gspread_helpers.py
@@ -258,7 +258,12 @@ def get_cttso_lims() -> (pd.DataFrame, pd.DataFrame):
     # Update legacy samples where pieriandx_submission_time is not set
     cttso_lims_df["pieriandx_submission_time"] = cttso_lims_df.apply(
         lambda x: x.pieriandx_case_creation_date
-        if pd.isna(x.pieriandx_submission_time) and not pd.isna(x.pieriandx_case_creation_date)
+        if (
+            pd.isnull(x.pieriandx_submission_time) or pd.isna(x.pieriandx_submission_time)
+        )
+        and not (
+            pd.isnull(x.pieriandx_case_creation_date) or pd.isna(x.pieriandx_case_creation_date)
+        )
         else x.pieriandx_submission_time,
         axis="columns"
     )

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/miscell.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/lambda_utils/miscell.py
@@ -4,6 +4,10 @@ from datetime import date, datetime, timezone
 from typing import List, Union
 import pytz
 from dateutil.parser import parse as date_parser
+from utils.logging import get_logger
+
+logger = get_logger()
+
 
 def change_case(column_name: str) -> str:
     """

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/requirements.txt
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/requirements.txt
@@ -5,6 +5,7 @@ gspread_pandas==3.2.2
 mypy_boto3_lambda==1.26.55
 mypy_boto3_secretsmanager==1.26.49
 mypy_boto3_ssm==1.26.43
+mypy_boto3_events==1.26.111
 numpy==1.24.2
 pandas==1.5.3
 pyriandx==0.3.0

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/requirements.txt
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/layers/requirements.txt
@@ -10,5 +10,5 @@ pandas==1.5.3
 pyriandx==0.3.0
 python_dateutil==2.8.2
 pytz==2022.7.1
-requests==2.28.2
+requests==2.31.0
 setuptools==67.2.0

--- a/deploy/cttso-ica-to-pieriandx-cdk/package-lock.json
+++ b/deploy/cttso-ica-to-pieriandx-cdk/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-cdk/aws-batch-alpha": "^2.39.1-alpha.0",
         "agentkeepalive": "^4.2.1",
-        "aws-cdk-lib": "^2.39.1",
+        "aws-cdk-lib": "^2.80.0",
         "constructs": "^10.1.91",
         "source-map-support": "^0.5.21"
       },
@@ -40,6 +40,21 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.196",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.196.tgz",
+      "integrity": "sha512-F8hU1rEzYS7z5Dt2s+ttd0/jMvPuUE9BcXexgq+dIOLuZsRpDwNnkMBtjNaJXJS48ZGJ2X4b8VlklseepdtoSA=="
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.165",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
+      "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
     },
     "node_modules/@aws-cdk/aws-batch-alpha": {
       "version": "2.39.1-alpha.0",
@@ -1258,9 +1273,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.39.1.tgz",
-      "integrity": "sha512-+KZBLBoCqq/TnC7LH8JMlQ+5IvKQtu7KHnVDiRmngtibLIXqLMVH4neKimNlSSIKhvSeOmqY2ZCaSp8v5szzrg==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz",
+      "integrity": "sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1270,17 +1285,22 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "fs-extra": "^11.1.1",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.5.1",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1295,12 +1315,49 @@
       "inBundle": true,
       "license": "Apache-2.0"
     },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
@@ -1325,37 +1382,75 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
+      "version": "11.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -1375,6 +1470,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1399,15 +1499,23 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.5.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1420,12 +1528,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -4517,6 +4688,21 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.196",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.196.tgz",
+      "integrity": "sha512-F8hU1rEzYS7z5Dt2s+ttd0/jMvPuUE9BcXexgq+dIOLuZsRpDwNnkMBtjNaJXJS48ZGJ2X4b8VlklseepdtoSA=="
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+    },
+    "@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.165",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
+      "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+    },
     "@aws-cdk/aws-batch-alpha": {
       "version": "2.39.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-batch-alpha/-/aws-batch-alpha-2.39.1-alpha.0.tgz",
@@ -5485,18 +5671,22 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.39.1.tgz",
-      "integrity": "sha512-+KZBLBoCqq/TnC7LH8JMlQ+5IvKQtu7KHnVDiRmngtibLIXqLMVH4neKimNlSSIKhvSeOmqY2ZCaSp8v5szzrg==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz",
+      "integrity": "sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==",
       "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "fs-extra": "^11.1.1",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.5.1",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -5504,8 +5694,29 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "at-least-node": {
-          "version": "1.0.0",
+        "ajv": {
+          "version": "8.12.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true
         },
         "balanced-match": {
@@ -5524,26 +5735,52 @@
           "version": "1.6.3",
           "bundled": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true
+        },
         "fs-extra": {
-          "version": "9.1.0",
+          "version": "11.1.1",
           "bundled": true,
           "requires": {
-            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.10",
+          "version": "4.2.11",
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.2.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
           "bundled": true
         },
         "jsonfile": {
@@ -5556,6 +5793,10 @@
         },
         "jsonschema": {
           "version": "1.4.1",
+          "bundled": true
+        },
+        "lodash.truncate": {
+          "version": "4.4.2",
           "bundled": true
         },
         "lru-cache": {
@@ -5573,19 +5814,66 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
           "bundled": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.5.1",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "universalify": {
           "version": "2.0.0",
           "bundled": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         },
         "yallist": {
           "version": "4.0.0",

--- a/deploy/cttso-ica-to-pieriandx-cdk/package.json
+++ b/deploy/cttso-ica-to-pieriandx-cdk/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-cdk/aws-batch-alpha": "^2.39.1-alpha.0",
     "agentkeepalive": "^4.2.1",
-    "aws-cdk-lib": "^2.39.1",
+    "aws-cdk-lib": "^2.80.0",
     "constructs": "^10.1.91",
     "source-map-support": "^0.5.21"
   }

--- a/deploy/cttso-ica-to-pieriandx-cdk/scripts/launch_clinical_payloads.sh
+++ b/deploy/cttso-ica-to-pieriandx-cdk/scripts/launch_clinical_payloads.sh
@@ -154,14 +154,14 @@ while read -r payload_line || [ -n "${payload_line}" ]; do
   echo "Launch sample ${counter} out of ${array_length}: Payload is"
   echo aws lambda invoke \
     --function-name "${AWS_LAMBDA_CLINICAL_LAUNCH_FUNCTION}" \
-    --invocation-type "RequestResponse" \
+    --invocation-type "Event" \
     --payload "${payload_json_str}" \
     --cli-binary-format "raw-in-base64-out" \
     "${lambda_output_file}"
 
   aws lambda invoke \
       --function-name "${AWS_LAMBDA_CLINICAL_LAUNCH_FUNCTION}" \
-      --invocation-type "RequestResponse" \
+      --invocation-type "Event" \
       --payload "${payload_json_str}" \
       --cli-binary-format "raw-in-base64-out" \
       "${lambda_output_file}"

--- a/deploy/cttso-ica-to-pieriandx-cdk/scripts/launch_validation_payloads.sh
+++ b/deploy/cttso-ica-to-pieriandx-cdk/scripts/launch_validation_payloads.sh
@@ -146,14 +146,14 @@ while read -r payload_line || [ -n "${payload_line}" ]; do
   echo "Launch sample ${counter} out of ${array_length}: Payload is"
   echo aws lambda invoke \
     --function-name "${AWS_LAMBDA_VALIDATION_LAUNCH_FUNCTION}" \
-    --invocation-type "RequestResponse" \
+    --invocation-type "Event" \
     --payload "${payload_json_str}" \
     --cli-binary-format "raw-in-base64-out" \
     "${lambda_output_file}"
 
   aws lambda invoke \
       --function-name "${AWS_LAMBDA_VALIDATION_LAUNCH_FUNCTION}" \
-      --invocation-type "RequestResponse" \
+      --invocation-type "Event" \
       --payload "${payload_json_str}" \
       --cli-binary-format "raw-in-base64-out" \
       "${lambda_output_file}"

--- a/deploy/cttso-ica-to-pieriandx-cdk/scripts/update-pieriandx-password.sh
+++ b/deploy/cttso-ica-to-pieriandx-cdk/scripts/update-pieriandx-password.sh
@@ -9,13 +9,24 @@ set -euo pipefail
 # Globals
 SECRET_ID="PierianDx/UserPassword"
 
+# Glocals
+env_midfix=""
+institution=""
+base_url=""
+
 # Get json file based on account
 account_id="$(aws sts get-caller-identity --output json | jq --raw-output '.Account')"
 
 if [[ "${account_id}" == "843407916570" ]]; then
   echo "Updating password in dev" 1>&2
+  env_midfix="dev"
+  institution="melbournetest"
+  base_url="https://app.uat.pieriandx.com/cgw-api/v2.0.0"
 elif [[ "${account_id}" == "472057503814" ]]; then
   echo "Updating password in prod" 1>&2
+  env_midfix="prod"
+  institution="melbourne"
+  base_url="https://app.pieriandx.com/cgw-api/v2.0.0"
 else
   echo "Please ensure you're logged in to either dev or prod" 1>&2
   exit 1
@@ -40,6 +51,50 @@ input_secret_json_str="$( \
 )"
 
 echo "Updating secret in ${account_id}" 1>&2
-aws secretsmanager update-secret \
-  --secret-id "${SECRET_ID}" \
-  --secret-string "${input_secret_json_str}"
+secret_version_id="$( \
+  aws secretsmanager update-secret \
+    --output json \
+    --secret-id "${SECRET_ID}" \
+    --secret-string "${input_secret_json_str}" | \
+  jq --raw-output ".VersionId" \
+)"
+
+echo "Got secret version id ${secret_version_id}" 1>&2
+
+echo "Sleeping 5 for secret to be fully updated" 1>&2
+sleep 5
+
+echo "Running lambda to update token" 1>&2
+aws lambda invoke \
+  --output json \
+  --function-name "cttso-ica-to-pieriandx-${env_midfix}-token-refresh-lambda-stack-lf" \
+  /dev/null > /dev/null
+
+echo "Sleep 5 for token to be fully updated" 1>&2
+sleep 5
+
+echo "Collecting token from aws secretsmanager" 1>&2
+new_auth_token="$( \
+  aws secretsmanager get-secret-value \
+    --secret-id PierianDx/UserAuthToken \
+    --output json | \
+  jq --raw-output \
+   '.SecretString | fromjson | .PierianDxUserAuthToken'
+)"
+
+echo "Listing All Cases" 1>&2
+if [[ "$( \
+  curl \
+    --fail --silent --location --show-error \
+    --request "GET" \
+    --url "${base_url}/case" \
+    --header "Accept: application/json" \
+    --header "X-Auth-Email: services@umccr.org" \
+    --header "X-Auth-Token: $new_auth_token" \
+    --header "X-Auth-Institution: $institution" | \
+  jq 'length > 0' \
+)" == "true" ]]; then
+  echo "Password changed successfully!" 1>&2
+else
+  echo "Error! Password changed however was not able to use generated token" 1>&2
+fi


### PR DESCRIPTION
### Fixes

* Fix Type Hinting for EventClient Type (https://github.com/umccr/cttso-ica-to-pieriandx/pull/71)
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/68
* Don't use RequestResponse event type when manually deploying lambdas (https://github.com/umccr/cttso-ica-to-pieriandx/pull/64)
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/63
* Get Incomplete Job Df from Gsuite doesn't collect pending jobs at times (https://github.com/umccr/cttso-ica-to-pieriandx/pull/66
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/61
* Fix submission time column https://github.com/umccr/cttso-ica-to-pieriandx/pull/65
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/59 
  
### Enhancements

* Added GH Actions check to ensure this changelog file has been updated before deployment (https://github.com/umccr/cttso-ica-to-pieriandx/pull/73)
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/70

* Added EventBridge kill switch if processing_df contains items included in the update_df (shouldn't happen) (https://github.com/umccr/cttso-ica-to-pieriandx/pull/67)
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/62

* Check if new password can successfully generate pieriandx session token before successfully exiting script (https://github.com/umccr/cttso-ica-to-pieriandx/pull/57)
  * Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/56

### Documentation

* Added coded-out main hint for local processing - https://github.com/umccr/cttso-ica-to-pieriandx/pull/72
  *  Fixes https://github.com/umccr/cttso-ica-to-pieriandx/issues/69
### Dependabot Updates

* Migrated from AWS 2.39.1 to 2.80.0 (https://github.com/umccr/cttso-ica-to-pieriandx/pull/74)