### PR TITLE
Fix job definition parameters

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lib/cttso-ica-to-pieriandx-batch-stack.ts
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lib/cttso-ica-to-pieriandx-batch-stack.ts
@@ -417,10 +417,10 @@ export class CttsoIcaToPieriandxBatchStack extends Stack {
             this,
             `${props.stack_prefix}-ecs-job-definition`,
             {
-                parameters: [
-                    ["dryrun"], "-",
-                    ["verbose"], "-"
-                ],
+                parameters: {
+                    ["dryrun"]: "-",
+                    ["verbose"]: "-"
+                },
                 container: new EcsEc2ContainerDefinition(
                     this,
                     `${props.stack_prefix}-ecs-container-job-definition`,


### PR DESCRIPTION
Fix parameters in job definition to use key-value pairs instead.