### PR TITLE
Use loc over iloc in pandas selection

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/launch_available_payloads_and_update_cttso_lims_sheet/lambda_code.py
@@ -263,7 +263,7 @@ def get_libraries_for_processing(merged_df) -> pd.DataFrame:
             logger.warning(f"Already run and deleted this combination {process_row['subject_id']} / {process_row['library_id']} / {process_row['portal_wfr_id']}, not reprocessing")
 
     # Delete via index
-    to_process_df = to_process_df.iloc[list(
+    to_process_df = to_process_df.loc[list(
         set(to_process_df.index.tolist()) - set(already_deleted_list_index)
     )]
 


### PR DESCRIPTION
Use loc over iloc when removing cases from processing df that have already been deleted


Resolves #153 