### PR TITLE
Coerce is_identified to boolean

### DIFF
--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/get_metadata_from_portal_and_defaults_and_launch_validation_workflow/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/get_metadata_from_portal_and_defaults_and_launch_validation_workflow/lambda_code.py
@@ -90,9 +90,15 @@ def lambda_handler(event, context):
         sample_type = VALIDATION_DEFAULTS["sample_type"]
 
     # Get is identified
-    is_identified: str
+    is_identified: any  # Union[str | bool] not supported in python=3.9
     if (is_identified := event.get("is_identified", None)) is None:
         is_identified = VALIDATION_DEFAULTS["is_identified"]
+
+    # Coerce is_identified to a boolean value
+    if isinstance(is_identified, str) and is_identified == 'identified':
+        is_identified = True
+    elif isinstance(is_identified, str) and is_identified == 'deidentified':
+        is_identified = False
 
     # Check disease name
     if (disease_name := event.get("disease_name", None)) is None:

--- a/deploy/cttso-ica-to-pieriandx-cdk/lambdas/get_metadata_from_portal_and_redcap_and_launch_clinical_workflow/lambda_code.py
+++ b/deploy/cttso-ica-to-pieriandx-cdk/lambdas/get_metadata_from_portal_and_redcap_and_launch_clinical_workflow/lambda_code.py
@@ -210,8 +210,15 @@ def lambda_handler(event, context):
     if (sample_type := event.get("sample_type", None)) is None:
         sample_type = CLINICAL_DEFAULTS["sample_type"].name.lower()
 
+    is_identified: any  # Union[str | bool] not supported in python=3.9
     if (is_identified := event.get("is_identified", None)) is None:
         is_identified = CLINICAL_DEFAULTS["is_identified"].name.lower()
+
+    # Coerce is_identified to a boolean value
+    if isinstance(is_identified, str) and is_identified == 'identified':
+        is_identified = True
+    elif isinstance(is_identified, str) and is_identified == 'deidentified':
+        is_identified = False
 
     # Set panel type (if not null)
     merged_df["panel_type"] = panel_type


### PR DESCRIPTION
This prevents any 'if' statement issues for string deidentified, which would return true.

Resolves #184 